### PR TITLE
fix: ci 커맨드 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: make test properties
         run: |
-          cd ./src/test/resources
+          mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml
           echo "${{ secrets.PROPERTIES_TEST }}" > ./application.yml
         shell: bash


### PR DESCRIPTION
CI 과정 중 ./src/test/resources폴더를 찾지 못하는 오류 발견.

폴더가 없는 경우에는 새로 생성하도록 오류 수정.