### PR TITLE
좋아요 기능 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
         run: |
           mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml
-          echo "${{ secrets.PROPERTIES_TEST }}" > ./application.yml
+          echo ${{ secrets.PROPERTIES_TEST }} | base64 --decode > src/test/resources/application.yml
         shell: bash
 
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-          arguments: build --stacktrace
+          arguments: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ jobs:
           distribution: 'temurin'
 
       - name: make test properties
+        env:
+          PROPERTIES_TEST: ${{ secrets.PROPERTIES_TEST }}
         run: |
           mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml
-          echo ${{ secrets.PROPERTIES_TEST }} | base64 --decode > application.yml
+          echo "$PROPERTIES_TEST" | base64 --decode > application.yml
         shell: bash
 
       - name: Build with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,9 @@ on:
   pull_request:
     branches: [ "dev", "main" ]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-          arguments: build
+          arguments: build --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml
-          echo ${{ secrets.PROPERTIES_TEST }} | base64 --decode > src/test/resources/application.yml
+          echo ${{ secrets.PROPERTIES_TEST }} | base64 --decode > application.yml
         shell: bash
 
       - name: Build with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
+      - uses: actions/checkout@v3
 
-    - name: make test properties
-      env:
-        PROPERTIES: ${{ secrets.PROPERTIES_TEST }}
-      run: |
-        mkdir -p ./src/test/resources && cd "$_"
-        touch ./application.yml
-        echo $PROPERTIES | base64 --decode > application.yml
-      shell: bash
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
 
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-      with:
-        arguments: build
+      - name: make test properties
+        env:
+          PROPERTIES: ${{ secrets.PROPERTIES_TEST }}
+        run: |
+          mkdir -p ./src/test/resources && cd "$_"
+          touch ./application.yml
+          echo $PROPERTIES | base64 --decode > application.yml
+        shell: bash
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
 
-      - name: make test properties
-        env:
-          PROPERTIES: ${{ secrets.CI_PROPERTIES }}
-        run: |
-          mkdir -p ./src/test/resources && cd "$_"
-          touch ./application.yml
-          echo $PROPERTIES | base64 --decode > application.yml
-        shell: bash
+    - name: make test properties
+      env:
+        PROPERTIES: ${{ secrets.PROPERTIES_TEST }}
+      run: |
+        mkdir -p ./src/test/resources && cd "$_"
+        touch ./application.yml
+        echo $PROPERTIES | base64 --decode > application.yml
+      shell: bash
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-        with:
-          arguments: build
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:
@@ -28,12 +29,10 @@ jobs:
           distribution: 'temurin'
 
       - name: make test properties
-        env:
-          PROPERTIES_TEST: ${{ secrets.PROPERTIES_TEST }}
         run: |
           mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml
-          echo $PROPERTIES_TEST | base64 --decode > application.yml
+          echo "${{ secrets.PROPERTIES_TEST }}" | base64 --decode > application.yml
         shell: bash
 
       - name: Build with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: make test properties
         env:
-          PROPERTIES: ${{ secrets.PROPERTIES_TEST }}
+          PROPERTIES: ${{ secrets.CI_PROPERTIES }}
         run: |
           mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [ "dev", "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,10 +26,12 @@ jobs:
           distribution: 'temurin'
 
       - name: make test properties
+        env:
+          PROPERTIES: ${{ secrets.PROPERTIES_TEST }}
         run: |
           mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml
-          echo "${{ secrets.PROPERTIES_TEST }}" | base64 --decode > application.yml
+          echo $PROPERTIES | base64 --decode > application.yml
         shell: bash
 
       - name: Build with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ "dev", "main" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           mkdir -p ./src/test/resources && cd "$_"
           touch ./application.yml
-          echo "$PROPERTIES_TEST" | base64 --decode > application.yml
+          echo $PROPERTIES_TEST | base64 --decode > application.yml
         shell: bash
 
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -59,3 +59,10 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+test {
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.8'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.8'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.dku'
@@ -9,52 +9,53 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	// spring boot
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.springframework.boot:spring-boot-starter-quartz'
+    // spring boot
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
 
-	// lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	// db
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // db
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// jsoup (html parser)
-	implementation 'org.jsoup:jsoup:1.15.4'
+    // jsoup (html parser)
+    implementation 'org.jsoup:jsoup:1.15.4'
 
-	// jwt
-	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
-	// swagger
-	annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
-	implementation 'org.springdoc:springdoc-openapi-javadoc:1.6.14'
+    // swagger
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
+    implementation 'org.springdoc:springdoc-openapi-javadoc:1.6.14'
 
-	// test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// db
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/dku/council/domain/like/PostLikeDumpTask.java
+++ b/src/main/java/com/dku/council/domain/like/PostLikeDumpTask.java
@@ -1,0 +1,19 @@
+package com.dku.council.domain.like;
+
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+@Slf4j
+public class PostLikeDumpTask extends QuartzJobBean {
+
+    @Autowired
+    PostLikeService service;
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) {
+        log.info("PostLikes in memory dump to DB.");
+        service.dumpToDB();
+    }
+}

--- a/src/main/java/com/dku/council/domain/like/PostLikeService.java
+++ b/src/main/java/com/dku/council/domain/like/PostLikeService.java
@@ -1,12 +1,18 @@
 package com.dku.council.domain.like;
 
+import com.dku.council.domain.like.model.LikeEntry;
+import com.dku.council.domain.like.model.LikeState;
 import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
 import com.dku.council.domain.like.repository.PostLikePersistenceRepository;
+import com.dku.council.domain.post.model.entity.Post;
+import com.dku.council.domain.post.repository.PostRepository;
+import com.dku.council.domain.user.model.entity.User;
+import com.dku.council.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +20,8 @@ public class PostLikeService {
 
     private final PostLikeMemoryRepository memoryRepository;
     private final PostLikePersistenceRepository persistenceRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
 
 
     /**
@@ -23,19 +31,14 @@ public class PostLikeService {
      * @param userId 사용자 ID
      */
     public void like(Long postId, Long userId) {
-        cacheLikesMembers(postId);
-        memoryRepository.addLikeMemberAt(postId, userId);
+        memoryRepository.addPostLike(postId, userId);
         increaseLikeCount(postId);
     }
 
     private void increaseLikeCount(Long postId) {
-        int count = memoryRepository.getCachedLikeCount(postId);
-        if (count == -1) {
-            count = persistenceRepository.countByPostId(postId);
-            memoryRepository.setLikeCount(postId, count + 1);
-        } else {
-            memoryRepository.increaseLikeCount(postId);
-        }
+        doCachedLikeCountTask(postId,
+                (count) -> memoryRepository.setLikeCount(postId, count + 1),
+                () -> memoryRepository.increaseLikeCount(postId));
     }
 
     /**
@@ -44,20 +47,15 @@ public class PostLikeService {
      * @param postId 게시글 ID
      * @param userId 사용자 ID
      */
-    public void unlike(Long postId, Long userId) {
-        cacheLikesMembers(postId);
-        memoryRepository.removeLikeMemberAt(postId, userId);
+    public void cancelLike(Long postId, Long userId) {
+        memoryRepository.removePostLike(postId, userId);
         decreaseLikeCount(postId);
     }
 
     private void decreaseLikeCount(Long postId) {
-        int count = memoryRepository.getCachedLikeCount(postId);
-        if (count == -1) {
-            count = persistenceRepository.countByPostId(postId);
-            memoryRepository.setLikeCount(postId, count - 1);
-        } else {
-            memoryRepository.increaseLikeCount(postId);
-        }
+        doCachedLikeCountTask(postId,
+                (count) -> memoryRepository.setLikeCount(postId, count - 1),
+                () -> memoryRepository.decreaseLikeCount(postId));
     }
 
     /**
@@ -65,20 +63,15 @@ public class PostLikeService {
      *
      * @param postId 게시글 ID
      * @param userId 사용자 ID
-     * @return 좋아요를 했는지?
+     * @return 좋아요를 했었는지 반환
      */
-    public boolean isLiked(Long postId, Long userId) {
-        cacheLikesMembers(postId);
-        return memoryRepository.containsLikeMemberAt(postId, userId);
-    }
-
-    private void cacheLikesMembers(Long postId) {
-        if (!memoryRepository.isCachedPost(postId)) {
-            List<Long> members = persistenceRepository.findAllByPostId(postId).stream()
-                    .map(ent -> ent.getUser().getId())
-                    .collect(Collectors.toList());
-            memoryRepository.setLikeMembers(postId, members);
+    public boolean isPostLiked(Long postId, Long userId) {
+        Boolean liked = memoryRepository.isPostLiked(postId, userId);
+        if (liked == null) {
+            liked = persistenceRepository.findByPostIdAndUserId(postId, userId).isPresent();
+            memoryRepository.removePostLike(postId, userId);
         }
+        return liked;
     }
 
     /**
@@ -89,10 +82,20 @@ public class PostLikeService {
      * @return 좋아요 개수
      */
     public int getCountOfLikes(Long postId) {
+        return doCachedLikeCountTask(postId,
+                (count) -> memoryRepository.setLikeCount(postId, count),
+                null);
+    }
+
+    private int doCachedLikeCountTask(Long postId, Consumer<Integer> onNotCached, Runnable onCached) {
         int count = memoryRepository.getCachedLikeCount(postId);
         if (count == -1) {
             count = persistenceRepository.countByPostId(postId);
-            memoryRepository.setLikeCount(postId, count);
+            if (onNotCached != null) {
+                onNotCached.accept(count);
+            }
+        } else if (onCached != null) {
+            onCached.run();
         }
         return count;
     }
@@ -101,6 +104,15 @@ public class PostLikeService {
      * 영속성 DB에 실제로 데이터를 반영한다.
      */
     public void dumpToDB() {
-        System.out.println("DUMP");
+        List<LikeEntry> allLikes = memoryRepository.getAllPostLikes();
+        for (LikeEntry ent : allLikes) {
+            if (ent.getState() == LikeState.LIKED) {
+                User user = userRepository.getReferenceById(ent.getUserId());
+                Post post = postRepository.getReferenceById(ent.getPostId());
+                persistenceRepository.save(new PostLike(user, post));
+            } else if (ent.getState() == LikeState.CANCELLED) {
+                persistenceRepository.deleteByPostIdAndUserId(ent.getPostId(), ent.getUserId());
+            }
+        }
     }
 }

--- a/src/main/java/com/dku/council/domain/like/PostLikeService.java
+++ b/src/main/java/com/dku/council/domain/like/PostLikeService.java
@@ -1,0 +1,106 @@
+package com.dku.council.domain.like;
+
+import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
+import com.dku.council.domain.like.repository.PostLikePersistenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+    private final PostLikeMemoryRepository memoryRepository;
+    private final PostLikePersistenceRepository persistenceRepository;
+
+
+    /**
+     * '좋아요' 처리
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     */
+    public void like(Long postId, Long userId) {
+        cacheLikesMembers(postId);
+        memoryRepository.addLikeMemberAt(postId, userId);
+        increaseLikeCount(postId);
+    }
+
+    private void increaseLikeCount(Long postId) {
+        int count = memoryRepository.getCachedLikeCount(postId);
+        if (count == -1) {
+            count = persistenceRepository.countByPostId(postId);
+            memoryRepository.setLikeCount(postId, count + 1);
+        } else {
+            memoryRepository.increaseLikeCount(postId);
+        }
+    }
+
+    /**
+     * '좋아요' 취소 처리
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     */
+    public void unlike(Long postId, Long userId) {
+        cacheLikesMembers(postId);
+        memoryRepository.removeLikeMemberAt(postId, userId);
+        decreaseLikeCount(postId);
+    }
+
+    private void decreaseLikeCount(Long postId) {
+        int count = memoryRepository.getCachedLikeCount(postId);
+        if (count == -1) {
+            count = persistenceRepository.countByPostId(postId);
+            memoryRepository.setLikeCount(postId, count - 1);
+        } else {
+            memoryRepository.increaseLikeCount(postId);
+        }
+    }
+
+    /**
+     * '좋아요'를 했었는지 확인
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     * @return 좋아요를 했는지?
+     */
+    public boolean isLiked(Long postId, Long userId) {
+        cacheLikesMembers(postId);
+        return memoryRepository.containsLikeMemberAt(postId, userId);
+    }
+
+    private void cacheLikesMembers(Long postId) {
+        if (!memoryRepository.isCachedPost(postId)) {
+            List<Long> members = persistenceRepository.findAllByPostId(postId).stream()
+                    .map(ent -> ent.getUser().getId())
+                    .collect(Collectors.toList());
+            memoryRepository.setLikeMembers(postId, members);
+        }
+    }
+
+    /**
+     * 게시글의 '좋아요' 개수 가져오기.
+     * 메모리에 '좋아요' 개수가 없다면 캐싱한다.
+     *
+     * @param postId 게시글 ID
+     * @return 좋아요 개수
+     */
+    public int getCountOfLikes(Long postId) {
+        int count = memoryRepository.getCachedLikeCount(postId);
+        if (count == -1) {
+            count = persistenceRepository.countByPostId(postId);
+            memoryRepository.setLikeCount(postId, count);
+        }
+        return count;
+    }
+
+    /**
+     * 영속성 DB에 실제로 데이터를 반영한다.
+     */
+    public void dumpToDB() {
+        System.out.println("DUMP");
+    }
+}

--- a/src/main/java/com/dku/council/domain/like/model/LikeEntry.java
+++ b/src/main/java/com/dku/council/domain/like/model/LikeEntry.java
@@ -1,0 +1,12 @@
+package com.dku.council.domain.like.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LikeEntry {
+    private final Long postId;
+    private final Long userId;
+    private final LikeState state;
+}

--- a/src/main/java/com/dku/council/domain/like/model/LikeEntry.java
+++ b/src/main/java/com/dku/council/domain/like/model/LikeEntry.java
@@ -1,9 +1,11 @@
 package com.dku.council.domain.like.model;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
+@EqualsAndHashCode
 @RequiredArgsConstructor
 public class LikeEntry {
     private final Long postId;

--- a/src/main/java/com/dku/council/domain/like/model/LikeState.java
+++ b/src/main/java/com/dku/council/domain/like/model/LikeState.java
@@ -1,0 +1,6 @@
+package com.dku.council.domain.like.model;
+
+public enum LikeState {
+    CANCELLED,
+    LIKED
+}

--- a/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
@@ -72,4 +72,11 @@ public interface PostLikeMemoryRepository {
      * @return '좋아요' entities
      */
     List<LikeEntry> getAllPostLikes();
+
+    /**
+     * 메모리에 저장된 모든 '좋아요' 데이터를 가져오고, 모두 삭제한다.
+     *
+     * @return '좋아요' entities
+     */
+    List<LikeEntry> getAllPostLikesAndClear();
 }

--- a/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
@@ -43,22 +43,6 @@ public interface PostLikeMemoryRepository {
     int getCachedLikeCount(Long postId);
 
     /**
-     * 게시글의 좋아요 개수 + 1.
-     * 게시글의 좋아요 개수가 캐싱되어있어야 정상 동작한다.
-     *
-     * @param postId 게시글 ID
-     */
-    void increaseLikeCount(Long postId);
-
-    /**
-     * 게시글의 좋아요 개수 - 1.
-     * 게시글의 좋아요 개수가 캐싱되어있어야 정상 동작한다.
-     *
-     * @param postId 게시글 ID
-     */
-    void decreaseLikeCount(Long postId);
-
-    /**
      * 게시글의 좋아요 개수 캐싱
      *
      * @param postId 게시글 ID

--- a/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
@@ -1,0 +1,82 @@
+package com.dku.council.domain.like.repository;
+
+import java.util.List;
+
+public interface PostLikeMemoryRepository {
+
+    /**
+     * 게시글 '좋아요' Set에 사용자 추가.
+     * 게시글에 '좋아요'한 사용자 목록이 캐싱되어있어야 정상 동작한다.
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     */
+    void addLikeMemberAt(Long postId, Long userId);
+
+    /**
+     * 게시글 '좋아요' Set에서 사용자 제거.
+     * 게시글에 '좋아요'한 사용자 목록이 캐싱되어있어야 정상 동작한다.
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     */
+    void removeLikeMemberAt(Long postId, Long userId);
+
+    /**
+     * 게시글 '좋아요' Set에 사용자가 포함되어있는지 확인
+     * 게시글에 '좋아요'한 사용자 목록이 캐싱되어있어야 정상 동작한다.
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     * @return 사용자가 포함되어있는지?
+     */
+    boolean containsLikeMemberAt(Long postId, Long userId);
+
+    /**
+     * 게시글에 '좋아요'한 사용자 목록이 메모리에 캐싱되어있는지?
+     *
+     * @param postId 게시글 ID
+     * @return 캐싱되어있는지?
+     */
+    boolean isCachedPost(Long postId);
+
+    /**
+     * 게시글에 '좋아요'한 사용자 목록을 캐싱
+     *
+     * @param postId  게시글 ID
+     * @param members '좋아요'한 사용자 목록
+     */
+    void setLikeMembers(Long postId, List<Long> members);
+
+    /**
+     * 메모리에 캐싱된 게시글의 좋아요 개수 확인.
+     *
+     * @param postId 게시글 ID
+     * @return 캐싱된 게시글의 좋아요 개수. 없으면 -1리턴.
+     */
+    int getCachedLikeCount(Long postId);
+
+    /**
+     * 게시글의 좋아요 개수 + 1.
+     * 게시글의 좋아요 개수가 캐싱되어있어야 정상 동작한다.
+     *
+     * @param postId 게시글 ID
+     */
+    void increaseLikeCount(Long postId);
+
+    /**
+     * 게시글의 좋아요 개수 - 1.
+     * 게시글의 좋아요 개수가 캐싱되어있어야 정상 동작한다.
+     *
+     * @param postId 게시글 ID
+     */
+    void decreaseLikeCount(Long postId);
+
+    /**
+     * 게시글의 좋아요 개수 캐싱
+     *
+     * @param postId 게시글 ID
+     * @param count  좋아요 개수
+     */
+    void setLikeCount(Long postId, int count);
+}

--- a/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/PostLikeMemoryRepository.java
@@ -1,52 +1,38 @@
 package com.dku.council.domain.like.repository;
 
+import com.dku.council.domain.like.model.LikeEntry;
+
 import java.util.List;
 
 public interface PostLikeMemoryRepository {
 
     /**
-     * 게시글 '좋아요' Set에 사용자 추가.
-     * 게시글에 '좋아요'한 사용자 목록이 캐싱되어있어야 정상 동작한다.
+     * 게시글 '좋아요' 추가
      *
      * @param postId 게시글 ID
      * @param userId 사용자 ID
      */
-    void addLikeMemberAt(Long postId, Long userId);
+    void addPostLike(Long postId, Long userId);
 
     /**
-     * 게시글 '좋아요' Set에서 사용자 제거.
-     * 게시글에 '좋아요'한 사용자 목록이 캐싱되어있어야 정상 동작한다.
+     * 게시글 '좋아요' 취소 처리. 실제로 삭제되진않고 취소되었다고
+     * 마킹만 해둔다. 그래야 나중에 캐싱되어있는지 확인할 수 있기 때문이다.
      *
      * @param postId 게시글 ID
      * @param userId 사용자 ID
      */
-    void removeLikeMemberAt(Long postId, Long userId);
+    void removePostLike(Long postId, Long userId);
 
     /**
-     * 게시글 '좋아요' Set에 사용자가 포함되어있는지 확인
-     * 게시글에 '좋아요'한 사용자 목록이 캐싱되어있어야 정상 동작한다.
+     * 메모리에서 사용자가 게시글에 '좋아요'를 눌렀는지 확인한다.
+     * 캐싱되어있는 경우에는 true/false로 반환하지만, 캐싱되어있지 않다면 null을
+     * 반환한다.
      *
      * @param postId 게시글 ID
      * @param userId 사용자 ID
-     * @return 사용자가 포함되어있는지?
+     * @return 사용자가 좋아요를 눌렀는지 반환. 캐싱된 데이터가 없다면 null반환.
      */
-    boolean containsLikeMemberAt(Long postId, Long userId);
-
-    /**
-     * 게시글에 '좋아요'한 사용자 목록이 메모리에 캐싱되어있는지?
-     *
-     * @param postId 게시글 ID
-     * @return 캐싱되어있는지?
-     */
-    boolean isCachedPost(Long postId);
-
-    /**
-     * 게시글에 '좋아요'한 사용자 목록을 캐싱
-     *
-     * @param postId  게시글 ID
-     * @param members '좋아요'한 사용자 목록
-     */
-    void setLikeMembers(Long postId, List<Long> members);
+    Boolean isPostLiked(Long postId, Long userId);
 
     /**
      * 메모리에 캐싱된 게시글의 좋아요 개수 확인.
@@ -79,4 +65,11 @@ public interface PostLikeMemoryRepository {
      * @param count  좋아요 개수
      */
     void setLikeCount(Long postId, int count);
+
+    /**
+     * 메모리에 저장된 모든 '좋아요' 데이터를 가져온다.
+     *
+     * @return '좋아요' entities
+     */
+    List<LikeEntry> getAllPostLikes();
 }

--- a/src/main/java/com/dku/council/domain/like/repository/PostLikePersistenceRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/PostLikePersistenceRepository.java
@@ -1,0 +1,15 @@
+package com.dku.council.domain.like.repository;
+
+import com.dku.council.domain.like.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostLikePersistenceRepository extends JpaRepository<PostLike, Long> {
+    List<PostLike> findAllByPostId(Long postId);
+    
+    Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
+
+    int countByPostId(Long postId);
+}

--- a/src/main/java/com/dku/council/domain/like/repository/PostLikePersistenceRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/PostLikePersistenceRepository.java
@@ -3,13 +3,13 @@ package com.dku.council.domain.like.repository;
 import com.dku.council.domain.like.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface PostLikePersistenceRepository extends JpaRepository<PostLike, Long> {
-    List<PostLike> findAllByPostId(Long postId);
-    
+
     Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
 
     int countByPostId(Long postId);
+
+    void deleteByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepository.java
@@ -53,16 +53,6 @@ public class PostLikeRedisRepository implements PostLikeMemoryRepository {
     }
 
     @Override
-    public void increaseLikeCount(Long postId) {
-        redisTemplate.opsForHash().increment(POST_LIKE_COUNT_KEY, postId, 1);
-    }
-
-    @Override
-    public void decreaseLikeCount(Long postId) {
-        redisTemplate.opsForHash().increment(POST_LIKE_COUNT_KEY, postId, -1);
-    }
-
-    @Override
     public void setLikeCount(Long postId, int count) {
         redisTemplate.opsForHash().put(POST_LIKE_COUNT_KEY, postId, count);
     }

--- a/src/main/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepository.java
@@ -1,0 +1,55 @@
+package com.dku.council.domain.like.repository.impl;
+
+import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class PostLikeRedisRepository implements PostLikeMemoryRepository {
+
+    @Override
+    public void addLikeMemberAt(Long postId, Long userId) {
+
+    }
+
+    @Override
+    public void removeLikeMemberAt(Long postId, Long userId) {
+
+    }
+
+    @Override
+    public boolean containsLikeMemberAt(Long postId, Long userId) {
+        return false;
+    }
+
+    @Override
+    public boolean isCachedPost(Long postId) {
+        return false;
+    }
+
+    @Override
+    public void setLikeMembers(Long postId, List<Long> members) {
+
+    }
+
+    @Override
+    public int getCachedLikeCount(Long postId) {
+        return 0;
+    }
+
+    @Override
+    public void increaseLikeCount(Long postId) {
+
+    }
+
+    @Override
+    public void decreaseLikeCount(Long postId) {
+
+    }
+
+    @Override
+    public void setLikeCount(Long postId, int count) {
+
+    }
+}

--- a/src/main/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepository.java
@@ -1,55 +1,94 @@
 package com.dku.council.domain.like.repository.impl;
 
+import com.dku.council.domain.like.model.LikeEntry;
+import com.dku.council.domain.like.model.LikeState;
 import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Repository
+@RequiredArgsConstructor
 public class PostLikeRedisRepository implements PostLikeMemoryRepository {
 
-    @Override
-    public void addLikeMemberAt(Long postId, Long userId) {
+    private static final String POST_LIKE_KEY = "PostLike";
+    private static final String POST_LIKE_COUNT_KEY = "PostLikeCount";
+    private static final String KEY_DELIMITER = ":";
 
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void addPostLike(Long postId, Long userId) {
+        String key = makeEntryKey(postId, userId);
+        redisTemplate.opsForHash().put(POST_LIKE_KEY, key, LikeState.LIKED.ordinal());
     }
 
     @Override
-    public void removeLikeMemberAt(Long postId, Long userId) {
-
+    public void removePostLike(Long postId, Long userId) {
+        String key = makeEntryKey(postId, userId);
+        redisTemplate.opsForHash().put(POST_LIKE_KEY, key, LikeState.CANCELLED.ordinal());
     }
 
     @Override
-    public boolean containsLikeMemberAt(Long postId, Long userId) {
-        return false;
-    }
-
-    @Override
-    public boolean isCachedPost(Long postId) {
-        return false;
-    }
-
-    @Override
-    public void setLikeMembers(Long postId, List<Long> members) {
-
+    public Boolean isPostLiked(Long postId, Long userId) {
+        String key = makeEntryKey(postId, userId);
+        Object value = redisTemplate.opsForHash().get(POST_LIKE_KEY, key);
+        if (value == null) {
+            return null;
+        }
+        return (int) value == LikeState.LIKED.ordinal(); // TODO Int로 막 바꿔도 됨?
     }
 
     @Override
     public int getCachedLikeCount(Long postId) {
-        return 0;
+        Object value = redisTemplate.opsForHash().get(POST_LIKE_COUNT_KEY, postId);
+        if (value == null) {
+            return -1;
+        }
+        return (int) value;
     }
 
     @Override
     public void increaseLikeCount(Long postId) {
-
+        redisTemplate.opsForHash().increment(POST_LIKE_COUNT_KEY, postId, 1);
     }
 
     @Override
     public void decreaseLikeCount(Long postId) {
-
+        redisTemplate.opsForHash().increment(POST_LIKE_COUNT_KEY, postId, -1);
     }
 
     @Override
     public void setLikeCount(Long postId, int count) {
+        redisTemplate.opsForHash().put(POST_LIKE_COUNT_KEY, postId, count);
+    }
 
+    @Override
+    public List<LikeEntry> getAllPostLikes() {
+        List<LikeEntry> result = new ArrayList<>();
+        try (Cursor<Map.Entry<Object, Object>> cursor =
+                     redisTemplate.opsForHash().scan(POST_LIKE_KEY, ScanOptions.NONE)) {
+            while (cursor.hasNext()) {
+                Map.Entry<Object, Object> entry = cursor.next();
+
+                String[] keyValue = ((String) entry.getKey()).split(KEY_DELIMITER);
+                Long postId = Long.valueOf(keyValue[0]);
+                Long userId = Long.valueOf(keyValue[1]);
+                LikeState state = LikeState.values()[(int) entry.getValue()];
+
+                result.add(new LikeEntry(postId, userId, state));
+            }
+        }
+        return result;
+    }
+
+    private String makeEntryKey(Long postId, Long userId) {
+        return postId.toString() + KEY_DELIMITER + userId;
     }
 }

--- a/src/main/java/com/dku/council/domain/post/model/entity/Post.java
+++ b/src/main/java/com/dku/council/domain/post/model/entity/Post.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.post.model.entity;
 
 import com.dku.council.domain.category.Category;
 import com.dku.council.domain.comment.entity.Comment;
+import com.dku.council.domain.like.PostLike;
 import com.dku.council.domain.post.model.PostStatus;
 import com.dku.council.domain.user.model.entity.User;
 import com.dku.council.global.base.BaseEntity;
@@ -57,6 +58,9 @@ public class Post extends BaseEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostLike> likes = new ArrayList<>();
 
     /**
      * 조회수

--- a/src/main/java/com/dku/council/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/dku/council/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.dku.council.domain.post.repository;
+
+import com.dku.council.domain.post.model.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/dku/council/domain/post/service/NewsService.java
+++ b/src/main/java/com/dku/council/domain/post/service/NewsService.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-// TODO Test it
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/com/dku/council/domain/user/model/Major.java
+++ b/src/main/java/com/dku/council/domain/user/model/Major.java
@@ -71,7 +71,8 @@ public enum Major {
      *
      * @param source MessageSource
      * @param major  학과 명
-     * @return 매칭되는 Major. 없으면 null
+     * @return 매칭되는 Major.
+     * @throws MajorNotFoundException 존재하지 않는 학과일 경우
      */
     public static Major of(MessageSource source, String major) {
         major = major.replace(" ", "")

--- a/src/main/java/com/dku/council/global/config/QuartzConfig.java
+++ b/src/main/java/com/dku/council/global/config/QuartzConfig.java
@@ -1,0 +1,38 @@
+package com.dku.council.global.config;
+
+import com.dku.council.domain.like.PostLikeDumpTask;
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class QuartzConfig {
+    private static final String ID_POST_LIKE_DUMP_TASK = "PostLikeDumpToDB";
+    private static final String GROUP_MAIN = "main";
+
+
+    @Bean
+    public JobDetail postLikeDumpJob(){
+        return JobBuilder.newJob(PostLikeDumpTask.class)
+                .withIdentity(new JobKey(ID_POST_LIKE_DUMP_TASK, GROUP_MAIN))
+                .storeDurably()
+                .build();
+    }
+
+    @Bean
+    public Trigger postLikeDumpTrigger() {
+        SimpleScheduleBuilder scheduleBuilder = SimpleScheduleBuilder
+                .simpleSchedule()
+                .withIntervalInMinutes(30)
+                .repeatForever();
+
+        return TriggerBuilder.newTrigger()
+                .forJob(postLikeDumpJob())
+                .withIdentity(new TriggerKey(ID_POST_LIKE_DUMP_TASK, GROUP_MAIN))
+                .withSchedule(scheduleBuilder)
+                .build();
+    }
+}

--- a/src/main/java/com/dku/council/global/config/QuartzConfig.java
+++ b/src/main/java/com/dku/council/global/config/QuartzConfig.java
@@ -4,9 +4,6 @@ import com.dku.council.domain.like.PostLikeDumpTask;
 import org.quartz.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.quartz.SchedulerFactoryBean;
-
-import javax.sql.DataSource;
 
 @Configuration
 public class QuartzConfig {

--- a/src/main/java/com/dku/council/global/config/RedisConfig.java
+++ b/src/main/java/com/dku/council/global/config/RedisConfig.java
@@ -1,0 +1,48 @@
+package com.dku.council.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private final String host;
+
+    @Value("${spring.redis.port}")
+    private final int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+        lettuceConnectionFactory.afterPropertiesSet();
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        Jackson2JsonRedisSerializer<Object> jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        RedisTemplate<?, ?> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(jackson2JsonRedisSerializer);
+        template.setValueSerializer(jackson2JsonRedisSerializer);
+        template.setHashKeySerializer(jackson2JsonRedisSerializer);
+        template.setHashValueSerializer(jackson2JsonRedisSerializer);
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/com/dku/council/infra/dku/exception/DkuFailedCrawlingException.java
+++ b/src/main/java/com/dku/council/infra/dku/exception/DkuFailedCrawlingException.java
@@ -1,11 +1,7 @@
 package com.dku.council.infra.dku.exception;
 
 import com.dku.council.global.error.exception.LocalizedMessageException;
-import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
-
-import java.util.List;
-import java.util.Locale;
 
 public class DkuFailedCrawlingException extends LocalizedMessageException {
 

--- a/src/main/java/com/dku/council/infra/dku/service/DkuCrawlerService.java
+++ b/src/main/java/com/dku/council/infra/dku/service/DkuCrawlerService.java
@@ -66,7 +66,7 @@ public class DkuCrawlerService {
         try {
             String pstnOrgzNm = getElementValueOrNull(doc, "pstnOrgzNm");
             pstnOrgzNm = pstnOrgzNm.trim().split(" ")[1];
-            major = Major.of(messageSource, pstnOrgzNm);
+            major = Major.of(messageSource, pstnOrgzNm); // TODO 존재하지 않는 학과일 경우는 어떻게 handling할 것인가?
 
             String etrsYy = getElementValueOrNull(doc, "etrsYy");
             yearOfAdmission = Integer.parseInt(etrsYy);

--- a/src/main/java/com/dku/council/infra/nhn/model/dto/response/ResponseToken.java
+++ b/src/main/java/com/dku/council/infra/nhn/model/dto/response/ResponseToken.java
@@ -3,8 +3,6 @@ package com.dku.council.infra.nhn.model.dto.response;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
-
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter

--- a/src/main/java/com/dku/council/infra/nhn/service/impl/NHNAuthServiceImpl.java
+++ b/src/main/java/com/dku/council/infra/nhn/service/impl/NHNAuthServiceImpl.java
@@ -2,18 +2,14 @@ package com.dku.council.infra.nhn.service.impl;
 
 import com.dku.council.infra.nhn.exception.CannotGetTokenException;
 import com.dku.council.infra.nhn.exception.NotInitializedException;
-import com.dku.council.infra.nhn.model.dto.request.RequestNHNCloudSMS;
 import com.dku.council.infra.nhn.model.dto.request.RequestToken;
 import com.dku.council.infra.nhn.model.dto.response.ResponseToken;
 import com.dku.council.infra.nhn.service.NHNAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
-import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.PostConstruct;

--- a/src/test/java/com/dku/council/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/dku/council/config/EmbeddedRedisConfig.java
@@ -1,0 +1,27 @@
+package com.dku.council.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import redis.embedded.RedisServer;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+@Configuration
+public class EmbeddedRedisConfig {
+    private final RedisServer redisServer;
+
+    public EmbeddedRedisConfig(@Value("${spring.redis.port}") int redisPort) {
+        this.redisServer = new RedisServer(redisPort);
+    }
+
+    @PostConstruct
+    public void startRedis() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        redisServer.stop();
+    }
+}

--- a/src/test/java/com/dku/council/domain/like/PostLikeServiceTest.java
+++ b/src/test/java/com/dku/council/domain/like/PostLikeServiceTest.java
@@ -1,0 +1,237 @@
+package com.dku.council.domain.like;
+
+import com.dku.council.domain.like.model.LikeEntry;
+import com.dku.council.domain.like.model.LikeState;
+import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
+import com.dku.council.domain.like.repository.PostLikePersistenceRepository;
+import com.dku.council.domain.post.model.entity.Post;
+import com.dku.council.domain.post.repository.PostRepository;
+import com.dku.council.domain.user.model.Major;
+import com.dku.council.domain.user.model.entity.User;
+import com.dku.council.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikeServiceTest {
+
+    @Mock
+    private PostLikeMemoryRepository memoryRepository;
+
+    @Mock
+    private PostLikePersistenceRepository persistenceRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostLikeService service;
+
+    @Test
+    @DisplayName("좋아요 - 캐시에 count가 없는 경우")
+    void likeNoCached() {
+        // given
+        when(memoryRepository.getCachedLikeCount(any())).thenReturn(-1);
+        when(persistenceRepository.countByPostId(any())).thenReturn(5);
+
+        // when
+        service.like(10L, 10L);
+
+        // then
+        verify(memoryRepository).addPostLike(10L, 10L);
+        verify(memoryRepository).setLikeCount(any(), eq(6));
+    }
+
+    @Test
+    @DisplayName("좋아요 - 캐시에 count가 있는 경우")
+    void likeCached() {
+        // given
+        when(memoryRepository.getCachedLikeCount(any())).thenReturn(5);
+
+        // when
+        service.like(10L, 10L);
+
+        // then
+        verify(memoryRepository).addPostLike(10L, 10L);
+        verify(memoryRepository).setLikeCount(any(), eq(6));
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 - 캐시에 count가 없는 경우")
+    void cancelLikeNoCached() {
+        // given
+        when(memoryRepository.getCachedLikeCount(any())).thenReturn(-1);
+        when(persistenceRepository.countByPostId(any())).thenReturn(5);
+
+        // when
+        service.cancelLike(10L, 10L);
+
+        // then
+        verify(memoryRepository).removePostLike(10L, 10L);
+        verify(memoryRepository).setLikeCount(any(), eq(4));
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 - 캐시에 count가 있는 경우")
+    void cancelLikeCached() {
+        // given
+        when(memoryRepository.getCachedLikeCount(any())).thenReturn(5);
+
+        // when
+        service.cancelLike(10L, 10L);
+
+        // then
+        verify(memoryRepository).removePostLike(10L, 10L);
+        verify(memoryRepository).setLikeCount(any(), eq(4));
+    }
+
+    @Test
+    @DisplayName("좋아요 확인 - 캐시에 좋아요가 등록된 경우")
+    void isPostLikedCached() {
+        // given
+        when(memoryRepository.isPostLiked(any(), any())).thenReturn(true);
+
+        // when
+        boolean liked = service.isPostLiked(10L, 10L);
+
+        // then
+        assertThat(liked).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("좋아요 확인 - 캐시에 좋아요가 등록안되었고 DB에도 없는 경우")
+    void isPostLikedNoCachedNoDB() {
+        // given
+        Optional<PostLike> result = Optional.empty();
+        when(memoryRepository.isPostLiked(any(), any())).thenReturn(null);
+        when(persistenceRepository.findByPostIdAndUserId(any(), any())).thenReturn(result);
+
+        // when
+        boolean liked = service.isPostLiked(10L, 10L);
+
+        // then
+        assertThat(liked).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("좋아요 확인 - 캐시에 좋아요가 등록안되었고 DB에는 있는 경우")
+    void isPostLikedNoCached() {
+        // given
+        Optional<PostLike> result = Optional.of(new PostLike());
+        when(memoryRepository.isPostLiked(any(), any())).thenReturn(null);
+        when(persistenceRepository.findByPostIdAndUserId(any(), any())).thenReturn(result);
+
+        // when
+        boolean liked = service.isPostLiked(10L, 10L);
+
+        // then
+        assertThat(liked).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("좋아요 개수 확인 - 캐싱된 경우")
+    void getCountOfLikesCached() {
+        // given
+        when(memoryRepository.getCachedLikeCount(any())).thenReturn(10);
+
+        // when
+        int likes = service.getCountOfLikes(10L);
+
+        // then
+        assertThat(likes).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("좋아요 개수 확인 - 캐싱안된 경우")
+    void getCountOfLikesNoCached() {
+        // given
+        when(memoryRepository.getCachedLikeCount(any())).thenReturn(-1);
+        when(persistenceRepository.countByPostId(any())).thenReturn(10);
+
+        // when
+        int likes = service.getCountOfLikes(10L);
+
+        // then
+        assertThat(likes).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Memory에 캐시된 좋아요를 DB로 dump")
+    void dumpToDB() {
+        // given
+        Stream<LikeEntry> likeStream = LongStream.range(0, 10)
+                .mapToObj(i -> new LikeEntry(i, i, LikeState.LIKED));
+        Stream<LikeEntry> cancelledStream = LongStream.range(10, 20)
+                .mapToObj(i -> new LikeEntry(i, i, LikeState.CANCELLED));
+        List<LikeEntry> likes = Stream.concat(likeStream, cancelledStream)
+                .collect(Collectors.toList());
+
+        when(memoryRepository.getAllPostLikes()).thenReturn(likes);
+        when(userRepository.getReferenceById(any()))
+                .thenAnswer(inv -> dummyUserWithId(inv.getArgument(0)));
+        when(postRepository.getReferenceById(any()))
+                .thenAnswer(inv -> dummyPostWithId(inv.getArgument(0)));
+
+        // when
+        service.dumpToDB();
+
+        // then
+        verify(persistenceRepository, times(10)).save(any(PostLike.class));
+
+        for (int i = 10; i < 20; i++) {
+            Long l = (long) i;
+            verify(persistenceRepository).deleteByPostIdAndUserId(l, l);
+        }
+    }
+
+    private User dummyUserWithId(Long id) throws NoSuchFieldException, IllegalAccessException {
+        User user = User.builder()
+                .classId("")
+                .password("")
+                .name("")
+                .major(Major.ADMIN)
+                .phone("")
+                .build();
+
+        // set id
+        Field field = User.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(user, id);
+
+        return user;
+    }
+
+    private Post dummyPostWithId(Long id) throws InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException, NoSuchMethodException {
+        Constructor<?> constructor = Post.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Post post = (Post) constructor.newInstance();
+
+        // set id
+        Field field = Post.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(post, id);
+
+        return post;
+    }
+}

--- a/src/test/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepositoryTest.java
+++ b/src/test/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.dku.council.domain.like.repository.impl;
+
+import org.junit.jupiter.api.Test;
+
+/** TODO 테스트 카테고라이징 필요.
+ * 느린 테스트, 빠른 테스트(유닛), 실제 테스트 등...
+ * gradle build 에서는 빠른 테스트만
+ */
+class PostLikeRedisRepositoryTest {
+
+    @Test
+    void addPostLike() {
+
+    }
+
+    @Test
+    void removePostLike() {
+
+    }
+
+    @Test
+    void isPostLiked() {
+
+    }
+
+    @Test
+    void getCachedLikeCount() {
+
+    }
+
+    @Test
+    void increaseLikeCount() {
+
+    }
+
+    @Test
+    void decreaseLikeCount() {
+
+    }
+
+    @Test
+    void setLikeCount() {
+
+    }
+
+    @Test
+    void getAllPostLikes() {
+
+    }
+}

--- a/src/test/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepositoryTest.java
+++ b/src/test/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepositoryTest.java
@@ -1,50 +1,282 @@
 package com.dku.council.domain.like.repository.impl;
 
+import com.dku.council.domain.like.model.LikeEntry;
+import com.dku.council.domain.like.model.LikeState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 
-/** TODO 테스트 카테고라이징 필요.
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TODO 테스트 카테고라이징 필요.
  * 느린 테스트, 빠른 테스트(유닛), 실제 테스트 등...
  * gradle build 에서는 빠른 테스트만
  */
+@SpringBootTest
 class PostLikeRedisRepositoryTest {
 
+    @Autowired
+    private PostLikeRedisRepository repository;
+
+    @Autowired
+    private RedisTemplate<String, Integer> redisTemplate;
+
+
+    @BeforeEach
+    void setup() {
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys != null) {
+            for (String key : keys) {
+                redisTemplate.delete(key);
+            }
+        }
+    }
+
     @Test
+    @DisplayName("like 엔티디가 잘 추가되는가?")
     void addPostLike() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
 
+        // when
+        repository.addPostLike(key.postId, key.userId);
+
+        // then
+        Object value = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_KEY, key.toString());
+        assertThat(value).isEqualTo(1);
     }
 
     @Test
+    @DisplayName("중복 추가시 덮어쓰기")
+    void addDuplicatedPostLike() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+        redisTemplate.opsForHash().put(PostLikeRedisRepository.POST_LIKE_KEY, key.toString(), 0);
+
+        // when
+        repository.addPostLike(key.postId, key.userId);
+
+        // then
+        Object value = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_KEY, key.toString());
+        assertThat(value).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 처리 - Entity가 있을 때")
     void removePostLike() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+        repository.addPostLike(key.postId, key.userId);
 
+        // when
+        repository.removePostLike(key.postId, key.userId);
+
+        // then
+        Object value = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_KEY, key.toString());
+        assertThat(value).isEqualTo(0);
     }
 
     @Test
+    @DisplayName("좋아요 취소 처리 - Entity가 없을 때")
+    void removePostLikeWhenNoEntry() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+
+        // when
+        repository.removePostLike(key.postId, key.userId);
+
+        // then
+        Object value = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_KEY, key.toString());
+        assertThat(value).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("좋아요 Entity가 존재하는지? - 있는 경우")
     void isPostLiked() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+        repository.addPostLike(key.postId, key.userId);
 
+        // when
+        Boolean value = repository.isPostLiked(key.postId, key.userId);
+
+        // then
+        assertThat(value).isEqualTo(true);
     }
 
     @Test
+    @DisplayName("좋아요 Entity가 존재하는지? - 취소된 경우")
+    void isPostLikedCancelled() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+        repository.removePostLike(key.postId, key.userId);
+
+        // when
+        Boolean value = repository.isPostLiked(key.postId, key.userId);
+
+        // then
+        assertThat(value).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("좋아요 Entity가 존재하는지? - 캐싱이 안된 경우")
+    void isPostLikedNoEntity() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+
+        // when
+        Boolean value = repository.isPostLiked(key.postId, key.userId);
+
+        // then
+        assertThat(value).isEqualTo(null);
+    }
+
+    @Test
+    @DisplayName("좋아요 수 가져오기 - 캐싱된 경우")
     void getCachedLikeCount() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+        redisTemplate.opsForHash().put(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId, 3);
 
+        // when
+        int count = repository.getCachedLikeCount(key.postId);
+
+        // then
+        assertThat(count).isEqualTo(3);
     }
 
     @Test
+    @DisplayName("좋아요 수 가져오기 - 캐싱안된 경우")
+    void getCachedLikeCountNoCached() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+
+        // when
+        int count = repository.getCachedLikeCount(key.postId);
+
+        // then
+        assertThat(count).isEqualTo(-1);
+    }
+
+    @Test
+    @DisplayName("캐싱된 좋아요 수에 +1")
     void increaseLikeCount() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+        redisTemplate.opsForHash().put(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId, 3);
 
+        // when
+        repository.increaseLikeCount(key.postId);
+
+        // then
+        Object count = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId);
+        assertThat(count).isEqualTo(4);
     }
 
     @Test
+    @DisplayName("캐싱된 좋아요 수에 -1")
     void decreaseLikeCount() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
+        redisTemplate.opsForHash().put(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId, 3);
 
+        // when
+        repository.decreaseLikeCount(key.postId);
+
+        // then
+        Object count = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId);
+        assertThat(count).isEqualTo(2);
     }
 
     @Test
+    @DisplayName("좋아요 수 직접 캐싱")
     void setLikeCount() {
+        // given
+        PostLikeKey key = new PostLikeKey(repository);
 
+        // when
+        repository.setLikeCount(key.postId, 8);
+
+        // then
+        Object count = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId);
+        assertThat(count).isEqualTo(8);
     }
 
     @Test
+    @DisplayName("캐싱된 모든 좋아요 가져오기")
     void getAllPostLikes() {
+        // given
+        final int count = 10;
+        PostLikeKey[] keys = new PostLikeKey[count];
+        for (int i = 0; i < count; i++) {
+            keys[i] = new PostLikeKey(repository, i + 100L, i + 100L);
+            if (i > count / 2) {
+                repository.removePostLike(keys[i].postId, keys[i].userId);
+            } else {
+                repository.addPostLike(keys[i].postId, keys[i].userId);
+            }
+        }
 
+        // when
+        List<LikeEntry> likes = repository.getAllPostLikes();
+
+        // then
+        Long size = redisTemplate.opsForHash().size(PostLikeRedisRepository.POST_LIKE_KEY);
+        LikeEntry[] expected = new LikeEntry[count];
+        for (int i = 0; i < count; i++) {
+            expected[i] = new LikeEntry(keys[i].postId, keys[i].userId,
+                    i > count / 2 ? LikeState.CANCELLED : LikeState.LIKED);
+        }
+
+        assertThat(likes).containsExactlyInAnyOrder(expected);
+        assertThat(size).isEqualTo(likes.size());
+    }
+
+    @Test
+    @DisplayName("캐싱된 모든 좋아요 가져오고 삭제가 잘 되는지?")
+    void getAllPostLikesAndClear() {
+        // given
+        final int count = 10;
+        for (int i = 0; i < count; i++) {
+            PostLikeKey key = new PostLikeKey(repository, i + 100L, i + 100L);
+            repository.addPostLike(key.postId, key.userId);
+        }
+
+        // when
+        List<LikeEntry> likes = repository.getAllPostLikesAndClear();
+
+        // then
+        Long size = redisTemplate.opsForHash().size(PostLikeRedisRepository.POST_LIKE_KEY);
+        assertThat(likes.size()).isEqualTo(count);
+        assertThat(size).isEqualTo(0);
+    }
+
+    private static class PostLikeKey {
+        private static final Random RAND = new Random();
+        private final Long postId;
+        private final Long userId;
+        private final String keyString;
+
+        public PostLikeKey(PostLikeRedisRepository repository) {
+            this(repository, RAND.nextLong(), RAND.nextLong());
+        }
+
+        public PostLikeKey(PostLikeRedisRepository repository, Long postId, Long userId) {
+            this.postId = postId;
+            this.userId = userId;
+            this.keyString = repository.makeEntryKey(postId, userId);
+        }
+
+        public String toString() {
+            return keyString;
+        }
     }
 }

--- a/src/test/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepositoryTest.java
+++ b/src/test/java/com/dku/council/domain/like/repository/impl/PostLikeRedisRepositoryTest.java
@@ -167,36 +167,6 @@ class PostLikeRedisRepositoryTest {
     }
 
     @Test
-    @DisplayName("캐싱된 좋아요 수에 +1")
-    void increaseLikeCount() {
-        // given
-        PostLikeKey key = new PostLikeKey(repository);
-        redisTemplate.opsForHash().put(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId, 3);
-
-        // when
-        repository.increaseLikeCount(key.postId);
-
-        // then
-        Object count = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId);
-        assertThat(count).isEqualTo(4);
-    }
-
-    @Test
-    @DisplayName("캐싱된 좋아요 수에 -1")
-    void decreaseLikeCount() {
-        // given
-        PostLikeKey key = new PostLikeKey(repository);
-        redisTemplate.opsForHash().put(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId, 3);
-
-        // when
-        repository.decreaseLikeCount(key.postId);
-
-        // then
-        Object count = redisTemplate.opsForHash().get(PostLikeRedisRepository.POST_LIKE_COUNT_KEY, key.postId);
-        assertThat(count).isEqualTo(2);
-    }
-
-    @Test
     @DisplayName("좋아요 수 직접 캐싱")
     void setLikeCount() {
         // given

--- a/src/test/java/com/dku/council/global/config/RedisConnectionTest.java
+++ b/src/test/java/com/dku/council/global/config/RedisConnectionTest.java
@@ -1,0 +1,37 @@
+package com.dku.council.global.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/**
+ * Redis Connection을 확인해보기위해 만든 더미 테스트
+ * 실제 CI에 사용될 테스트는 아니다.
+ */
+class RedisConnectionTest {
+
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    public void init() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration("localhost", 6379);
+        LettuceConnectionFactory redisConnectionFactory = new LettuceConnectionFactory(configuration);
+        redisConnectionFactory.afterPropertiesSet();
+        this.redisTemplate = new StringRedisTemplate(redisConnectionFactory);
+    }
+
+    @Test
+    @DisplayName("Redis Connection을 가지고 놀아보는 놀이터")
+    @Disabled
+    public void connectionPlayground() {
+        redisTemplate.opsForSet().add("like:post:1", "user_1");
+        redisTemplate.opsForSet().add("like:post:1", "user_2");
+        redisTemplate.opsForSet().add("like:post:1", "user_3");
+        redisTemplate.opsForSet().add("like:post:2", "user_2");
+        redisTemplate.opsForSet().add("like:post:2", "user_3");
+    }
+}

--- a/src/test/java/com/dku/council/util/MockServerUtil.java
+++ b/src/test/java/com/dku/council/util/MockServerUtil.java
@@ -73,8 +73,11 @@ public class MockServerUtil {
     public static String readMockData(String path) {
         String name = "/mockdata/" + path;
         log.debug("Load mocking data: {}", name);
+        return readResource(name);
+    }
 
-        try (InputStream inStream = MockServerUtil.class.getResourceAsStream(name);
+    public static String readResource(String path) {
+        try (InputStream inStream = MockServerUtil.class.getResourceAsStream(path);
              InputStreamReader reader = new InputStreamReader(inStream, StandardCharsets.UTF_8)) {
             return readStringFromReader(reader);
         } catch (IOException e) {

--- a/src/test/java/com/dku/council/util/PropertiesBase64Encoder.java
+++ b/src/test/java/com/dku/council/util/PropertiesBase64Encoder.java
@@ -1,0 +1,20 @@
+package com.dku.council.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+public class PropertiesBase64Encoder {
+
+    @Test
+    public void propertiesEncode() {
+        try {
+            String properties = MockServerUtil.readResource("/application.yml");
+            String encoded = Base64.getEncoder().encodeToString(properties.getBytes());
+            System.out.println("========================= Encoded Properties String =========================");
+            System.out.println(encoded);
+        } catch (NullPointerException e){
+            System.out.println("Can't find resource yml. Encoding task ignored");
+        }
+    }
+}


### PR DESCRIPTION
# Redis 도입

좋아요 기능 구현에 Redis를 활용했습니다. 실시간으로 DB에 업데이트하지 않고, Redis Storage에 저장해두었다가 30분 간격으로 DB에 한번에 입력합니다.

# Quartz 도입

30분 간격으로 스케쥴링 처리가 필요해서 Quartz를 도입했습니다. Quartz는 스프링 스케쥴러보다 더 많은 기능을 제공합니다.

 - 스케쥴러간 클러스터링 기능 (분산처리 가능)
 - DB에 state를 저장해두면서 동작
   - DB를 통해 스케쥴 모니터링 가능
   - 도중에 서버가 꺼지는 등의 문제 발생시 스케쥴링 작업들 복구 가능
  
향후 MSA를 도입할 때 클러스터링 기능이 유용하게 쓰일 것 같아서 도입했습니다. 다만 아직까지는 큰 장점은 못 느끼겠어서 뺄 수도 있습니다.

# 좋아요 처리 방법

우리는 Redis에서 HashMap형태의 자료구조를 사용합니다. 기본적으로 모든 영속 데이터는 DB에 저장됩니다. 그래서 DB에 바로 저장하고 불러와도 되지만, 중간에 Redis를 사용해서 캐싱하면 훨씬 빠른 IO가 가능합니다.

### 좋아요 누르면

HashMap에 Key가 "post_id:user_id", Value가 "1"인 엔트리를 저장합니다. 예를 들어 post_Id=3, user_id=5라면 좋아요 눌렀을 때 HashMap에는 "3:5"="1" 의 형태로 저장됩니다.

### 좋아요 취소하면

HashMap에 Key가 "post_id:user_id", Value가 "0"인 엔트리를 저장합니다. 위와 같은 예시라면 "3:5"="0"이 저장됩니다. 만약 이미 저장된 요소가 있다면 HashMap과 같이 덮어씌워집니다.

### 배치 처리 (30분마다)

HashMap에 저장된 모든 요소를 꺼내옵니다. 그리고 Value가 1인 엔트리들은 모두 DB에 추가하고, 0인 엔트리들은 모두 삭제합니다. (DB에 없으면 삭제 안됩니다.)

### 특정 유저가 좋아요 눌렀는지 확인

HashMap에 Key가 "post_id:user_id"인 요소가 있고, 값이 1이라면 좋아요를 누른 것입니다. 값이 0이라면 안 누른 상태겠죠? 만약 아얘 저장된 Key가 없으면 DB에서 끌어옵니다.

위에서 의문점이 있으실텐데, 좋아요 취소할 때 그냥 0인 엔트리를 저장하는 게 아니라 삭제하면 되지 않나? 싶으실겁니다.

굳이 0인 엔트리를 저장하는 이유는 캐싱이 되어있는지 확인하기 위해서입니다. 만약 그냥 좋아요 취소했을 때 Redis에서 삭제해버리면, 나중에 Redis를 확인할 때 그 값이 캐싱이 되어있는지 안되어있는지 확인할 방법이 없습니다. 그래서 결국 Redis, DB 둘 다 탐색해야합니다.

### 좋아요 개수 세는 방법

일반적인 캐싱 방법과 동일합니다. Redis에서 먼저 가져와보고, 없으면 DB에서 가져와서 캐싱하고 반환합니다.